### PR TITLE
Windows compatible, branch support, use GitPython instead of os.system

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -1,32 +1,25 @@
-print("   _____ _ _    _____ _                       ")
-print("  / ____(_) |  / ____| |                      ")
-print(" | |  __ _| |_| |    | | ___  _ __   ___ _ __ ")
-print(" | | |_ | | __| |    | |/ _ \| '_ \ / _ \ '__|")
-print(" | |__| | | |_| |____| | (_) | | | |  __/ |   ")
-print("  \_____|_|\__|\_____|_|\___/|_| |_|\___|_|  ")
-print("\n")
+from git import *
 
-
-
+logo = """
+  _____ _ _    _____ _   
+ / ____(_) |  / ____| |                      
+| |  __ _| |_| |    | | ___  _ __   ___ _ __
+| | |_ | | __| |    | |/ _ \| '_ \ / _ \ '__|
+| |__| | | |_| |____| | (_) | | | |  __/ |
+ \_____|_|\__|\_____|_|\___/|_| |_|\___|_|"""
+print(logo)
 vers = "v1.0"
 print("By: Talon 'XxTvanderb' Vanderbeken")
 print("Version: " + vers)
 
 gitURL = input("Enter the link to the Github Repository: ")
-directory = input("Eter directory to clone to: ")
-import os
-dire = directory
-andAnd= " && "
-url = gitURL
-cloneC = "sudo git clone "
-cd = "cd "
-com = cd + andAnd + cd + dire + andAnd + cloneC + url
-os.system(com)
+directory = input("Enter directory to clone to: ")
+branch = input("Enter the repo's branch ")
 
-    
-                    
+repo = Repo.clone_from(
+     gitURL, directory,
+     branch=branch
+)
 
+print("Cloned", gitURL, "into", directory)
 
-               
-
-    


### PR DESCRIPTION
Using GitPython library is a better way to clone using python!
use "pip install GitPython" or "pip3 install GitPython" to install the library.